### PR TITLE
Updated data-collection to include which client uploaded the data per experiment

### DIFF
--- a/DynamicFlightStorageSimulation/DataCollection/ConsumerDataLogger.cs
+++ b/DynamicFlightStorageSimulation/DataCollection/ConsumerDataLogger.cs
@@ -36,7 +36,7 @@ namespace DynamicFlightStorageSimulation.DataCollection
             }
         }
 
-        public async Task PersistDataAsync(string experimentId)
+        public async Task PersistDataAsync(string experimentId, string clientId)
         {
             if (!IsLoggingEnabled)
             {
@@ -44,6 +44,7 @@ namespace DynamicFlightStorageSimulation.DataCollection
             }
 
             ArgumentNullException.ThrowIfNull(experimentId, nameof(experimentId));
+            ArgumentNullException.ThrowIfNull(clientId, nameof(clientId));
 
             var flightData = MessagePackSerializer.Serialize(_flightLog, MessagePackOptions);
             var weatherData = MessagePackSerializer.Serialize(_weatherLog, MessagePackOptions);
@@ -58,12 +59,14 @@ namespace DynamicFlightStorageSimulation.DataCollection
             dbContext.WeatherEventLogs.Add(new ExperimentOrchestrator.DataCollection.Entities.WeatherEventLog()
             {
                 ExperimentId = experimentId,
+                ClientId = clientId,
                 WeatherData = weatherData,
                 UtcTimeStamp = DateTime.UtcNow
             });
             dbContext.FlightEventLogs.Add(new ExperimentOrchestrator.DataCollection.Entities.FlightEventLog()
             {
                 ExperimentId = experimentId,
+                ClientId = clientId,
                 FlightData = flightData,
                 UtcTimeStamp = DateTime.UtcNow
             });

--- a/DynamicFlightStorageSimulation/DataCollection/Entities/FlightEventLog.cs
+++ b/DynamicFlightStorageSimulation/DataCollection/Entities/FlightEventLog.cs
@@ -12,6 +12,8 @@ namespace DynamicFlightStorageSimulation.ExperimentOrchestrator.DataCollection.E
 
         public required string ExperimentId { get; init; }
 
+        public required string ClientId { get; init; }
+
         public required byte[] FlightData { get; init; }
 
         public required DateTime UtcTimeStamp { get; init; }

--- a/DynamicFlightStorageSimulation/DataCollection/Entities/RecalculationEventLog.cs
+++ b/DynamicFlightStorageSimulation/DataCollection/Entities/RecalculationEventLog.cs
@@ -12,6 +12,8 @@ namespace DynamicFlightStorageSimulation.ExperimentOrchestrator.DataCollection.E
 
         public required string ExperimentId { get; init; }
 
+        public required string ClientId { get; init; }
+
         public required string FlightId { get; init; }
 
         public required DateTime UtcTimeStamp { get; init; }

--- a/DynamicFlightStorageSimulation/DataCollection/Entities/WeatherEventLog.cs
+++ b/DynamicFlightStorageSimulation/DataCollection/Entities/WeatherEventLog.cs
@@ -12,6 +12,8 @@ namespace DynamicFlightStorageSimulation.ExperimentOrchestrator.DataCollection.E
 
         public required string ExperimentId { get; init; }
 
+        public required string ClientId { get; init; }
+
         public required byte[] WeatherData { get; init; }
 
         public required DateTime UtcTimeStamp { get; init; }

--- a/DynamicFlightStorageSimulation/DataCollection/ExperimentDataCollector.cs
+++ b/DynamicFlightStorageSimulation/DataCollection/ExperimentDataCollector.cs
@@ -73,6 +73,7 @@ namespace DynamicFlightStorageSimulation.ExperimentOrchestrator.DataCollection
             _recalculationLogs.Add(new RecalculationEventLog()
             {
                 ExperimentId = _eventBus.CurrentExperimentId,
+                ClientId = _eventBus.ClientId,
                 UtcTimeStamp = flight.RecalculatedTime,
                 FlightId = flight.FlightIdentification
             });

--- a/DynamicFlightStorageSimulation/SimulationConsumer.cs
+++ b/DynamicFlightStorageSimulation/SimulationConsumer.cs
@@ -127,7 +127,7 @@ namespace DynamicFlightStorageSimulation
                     await ResetStateAsync(message).ConfigureAwait(false);
                     break;
                 case SystemMessage.SystemMessageType.ExperimentComplete:
-                    await _consumerLogger.PersistDataAsync(_simulationEventBus.CurrentExperimentId).ConfigureAwait(false);
+                    await _consumerLogger.PersistDataAsync(_simulationEventBus.CurrentExperimentId, ClientId).ConfigureAwait(false);
                     _consumerLogger.ResetLogger();
                     break;
                 default:

--- a/DynamicFlightStorageUI/Components/Pages/ExperimentView.razor
+++ b/DynamicFlightStorageUI/Components/Pages/ExperimentView.razor
@@ -2,6 +2,7 @@
 @using Microsoft.EntityFrameworkCore;
 @page "/experiments/{id:int}"
 @inject DataCollectionContext dbContext
+@inject NavigationManager navManager
 <nav style="--bs-breadcrumb-divider: '>';" aria-label="breadcrumb">
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="experiments">Experiments</a></li>
@@ -41,6 +42,14 @@
                         <p class="mb-1"><strong>Data Store Type:</strong> @clientResult.DataStoreType</p>
                         <p class="mb-1"><strong>Max Flight Consumer Lag:</strong> @clientResult.MaxFlightConsumerLag</p>
                         <p class="mb-1"><strong>Max Weather Consumer Lag:</strong> @clientResult.MaxWeatherConsumerLag</p>
+                        @if(RecalculationCount.TryGetValue(clientResult.ClientId, out var count))
+                        {
+                            <p class="mb-1"><strong>Recalculation Events:</strong> @RecalculationCount[clientResult.ClientId]</p>
+                        }
+                        else
+                        {
+                            <p class="mb-1"><strong>Recalculation Events:</strong> <span style="color:red">No recalculation-events are stored for this client-id</span></p>
+                        }
                         @if (clientResult.LatencyTest != null)
                         {
                             <h5>Latency Test Result</h5>
@@ -51,14 +60,40 @@
                             <p class="mb-1"><strong>Median Latency:</strong> @clientResult.LatencyTest.MedianLatencyMs.ToString(".00") ms.</p>
                             <p class="mb-1"><strong>Standard Deviation Latency:</strong> @clientResult.LatencyTest.StdDeviationLatency</p>
                         }
+                        @if(WeatherData.TryGetValue(clientResult.ClientId, out var weatherData))
+                        {
+                            <h5>Collected Weather Data</h5>
+                            <ul>
+                            @foreach (var data in weatherData)
+                            {
+                                 <li><a href="@GetWeatherDownloadUrl(data.DownloadId)">@data.Desc</a></li>
+                            }
+                            </ul>
+                        }
+                        else
+                        {
+                            <p>There is no available weather data</p>
+                        }
+                        @if (FlightData.TryGetValue(clientResult.ClientId, out var flightData))
+                        {
+                            <h5>Collected Flight Data</h5>
+                            <ul>
+                                @foreach (var data in flightData)
+                                {
+                                    <li><a href="@GetFlightDownloadUrl(data.DownloadId)">@data.Desc</a></li>
+                                }
+                            </ul>
+                        }
+                        else
+                        {
+                            <p>There is no available flight data</p>
+                        }
+
                     </div>
                 }
             </div>
         }
     </div>
-    
-
-
 }
 else
 {
@@ -66,16 +101,51 @@ else
 }
 
 @code {
+    private const string FlightDownloadTemplate = "api/flightlogs/{0}";
+    private const string WeatherDownloadTemplate = "api/weatherlogs/{0}";
 
     private ExperimentResult? ExperimentResult { get; set; }
+    private Dictionary<string, List<(int DownloadId, string ClientId, string Desc)>> WeatherData = new ();
+    private Dictionary<string, List<(int DownloadId, string ClientId, string Desc)>> FlightData = new();
+    private Dictionary<string, int> RecalculationCount { get; set; } = new();
     protected async override Task OnInitializedAsync()
     {
         ExperimentResult = await dbContext.ExperimentResults
-            .Include(x=>x.Experiment)
-            .Include(x=>x.ClientResults)
-            .ThenInclude(x=>x.LatencyTest)
+            .Include(x => x.Experiment)
+            .Include(x => x.ClientResults)
+            .ThenInclude(x => x.LatencyTest)
             .FirstOrDefaultAsync(x => x.Id == Id);
+
+        var clientIds = ExperimentResult!.ClientResults.Select(x => x.ClientId).Distinct().ToList();
+
+        WeatherData = (await dbContext.WeatherEventLogs
+            .Where(x => clientIds.Contains(x.ClientId))
+            .Select(x => new { x.Id, x.ClientId, x.UtcTimeStamp, Size = x.WeatherData.Length })
+            .ToListAsync())
+                .Select(x => (x.Id, x.ClientId, $"{x.UtcTimeStamp} (~{BytesToMb(x.Size)} MB)"))
+                .GroupBy(x => x.ClientId)
+                .ToDictionary(x => x.Key, x => x.ToList());
+
+        FlightData = (await dbContext.FlightEventLogs
+            .Where(x => clientIds.Contains(x.ClientId))
+            .Select(x => new { x.Id, x.ClientId, x.UtcTimeStamp, Size = x.FlightData.Length })
+            .ToListAsync())
+                .Select(x => (x.Id, x.ClientId, $"{x.UtcTimeStamp} (~{BytesToMb(x.Size)} MB)"))
+                .GroupBy(x => x.ClientId)
+                .ToDictionary(x => x.Key, x => x.ToList());
+
+        RecalculationCount = (await dbContext.RecalculationEventLogs
+                                .Where(x => clientIds.Contains(x.ClientId))
+                                .GroupBy(x=>x.ClientId)
+                                .Select(x => new { Id = x.Key, Count = x.Count() })
+                                .ToListAsync())
+                                    .ToDictionary(x => x.Id, x => x.Count);
     }
+
+    private double BytesToMb(int bytes) => Math.Round(bytes / 1024d / 1024d, 2);
+
+    private string GetFlightDownloadUrl(int id) => navManager.BaseUri + string.Format(FlightDownloadTemplate, id);
+    private string GetWeatherDownloadUrl(int id) => navManager.BaseUri + string.Format(WeatherDownloadTemplate, id);
 
     [Parameter]
     public int Id { get; set; }

--- a/DynamicFlightStorageUI/ExperimentLoggingEndpoints.cs
+++ b/DynamicFlightStorageUI/ExperimentLoggingEndpoints.cs
@@ -11,18 +11,10 @@ namespace DynamicFlightStorageUI
         public static void AddExperimentLogEndpoints(this WebApplication app)
         {
             // TODO: Either don't deploy this somewhere public or add authentication
-            app.MapGet("/api/experiment", async (DataCollectionContext context, HttpContext httpContext) =>
-            {
-                httpContext.Response.ContentType = "application/json";
-                return Results.Ok(await context.Experiments.ToListAsync());
-            });
-
-            app.MapGet("/api/experiment/{experimentId}/flightlogs", async (DataCollectionContext context, HttpContext httpContext, string experimentId) =>
+            app.MapGet("/api/flightlogs/{id:int}", async (DataCollectionContext context, HttpContext httpContext, int id) =>
             {
                 var logs = await context.FlightEventLogs
-                    .Where(log => log.ExperimentId == experimentId)
-                    .OrderBy(log => log.UtcTimeStamp)
-                    .FirstOrDefaultAsync();
+                    .FirstOrDefaultAsync(x => x.Id == id);
 
                 if (logs is null)
                 {
@@ -33,15 +25,13 @@ namespace DynamicFlightStorageUI
 
                 return Results.File(System.Text.Encoding.UTF8.GetBytes(JsonSerializer.Serialize(logList)),
                     "application/json",
-                    $"flightlogs_{experimentId}.json");
-            });
+                    $"flightlogs_{logs.ExperimentId}_{logs.ClientId}.json");
+            }).WithName("flightlog_download");
 
-            app.MapGet("/api/experiment/{experimentId}/weatherlogs", async (DataCollectionContext context, HttpContext httpContext, string experimentId) =>
+            app.MapGet("/api/weatherlogs/{id:int}", async (DataCollectionContext context, HttpContext httpContext, int id) =>
             {
                 var logs = await context.WeatherEventLogs
-                    .Where(log => log.ExperimentId == experimentId)
-                    .OrderBy(log => log.UtcTimeStamp)
-                    .FirstOrDefaultAsync();
+                    .FirstOrDefaultAsync(x => x.Id == id);
 
                 if (logs is null)
                 {
@@ -52,8 +42,8 @@ namespace DynamicFlightStorageUI
 
                 return Results.File(System.Text.Encoding.UTF8.GetBytes(JsonSerializer.Serialize(logList)),
                     "application/json",
-                    $"weatherlogs_{experimentId}.json");
-            });
+                    $"weatherlogs_{logs.ExperimentId}_{logs.ClientId}.json");
+            }).WithName("weatherlog_download");
         }
     }
 }

--- a/dynamicflightstorage_schema.sql
+++ b/dynamicflightstorage_schema.sql
@@ -1,0 +1,268 @@
+-- phpMyAdmin SQL Dump
+-- version 5.2.1
+-- https://www.phpmyadmin.net/
+--
+-- Vært: hosting.alexandernorup.com
+-- Genereringstid: 10. 02 2025 kl. 10:14:56
+-- Serverversion: 10.5.23-MariaDB-0+deb11u1-log
+-- PHP-version: 8.3.16
+
+SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
+START TRANSACTION;
+SET time_zone = "+00:00";
+
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
+
+--
+-- Database: `dynamicflightstorage`
+--
+
+-- --------------------------------------------------------
+
+--
+-- Struktur-dump for tabellen `EventLog_Flight`
+--
+
+CREATE TABLE `EventLog_Flight` (
+  `Id` int(11) NOT NULL,
+  `ExperimentId` varchar(36) NOT NULL,
+  `ClientId` varchar(255) DEFAULT NULL,
+  `FlightData` longblob NOT NULL,
+  `UtcTimeStamp` datetime NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Struktur-dump for tabellen `EventLog_Recalculation`
+--
+
+CREATE TABLE `EventLog_Recalculation` (
+  `Id` int(11) NOT NULL,
+  `ExperimentId` varchar(36) NOT NULL,
+  `ClientId` varchar(255) NOT NULL,
+  `FlightId` varchar(36) NOT NULL,
+  `UtcTimeStamp` datetime NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Struktur-dump for tabellen `EventLog_Weather`
+--
+
+CREATE TABLE `EventLog_Weather` (
+  `Id` int(11) NOT NULL,
+  `ExperimentId` varchar(36) NOT NULL,
+  `ClientId` varchar(255) DEFAULT NULL,
+  `WeatherData` longblob NOT NULL,
+  `UtcTimeStamp` datetime NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Struktur-dump for tabellen `Experiment`
+--
+
+CREATE TABLE `Experiment` (
+  `Id` varchar(36) NOT NULL,
+  `Name` varchar(50) NOT NULL,
+  `TimeScale` double NOT NULL,
+  `LoggingEnabled` tinyint(1) NOT NULL DEFAULT 0,
+  `SimulatedStartTime` datetime NOT NULL,
+  `SimulatedEndTime` datetime NOT NULL,
+  `SimulatedPreloadStartTime` datetime NOT NULL,
+  `SimulatedPreloadEndTime` datetime NOT NULL,
+  `PreloadAllFlights` tinyint(1) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Struktur-dump for tabellen `ExperimentClientResult`
+--
+
+CREATE TABLE `ExperimentClientResult` (
+  `Id` int(11) NOT NULL,
+  `ExperimentResultId` int(11) NOT NULL,
+  `ClientId` varchar(255) NOT NULL,
+  `DataStoreType` varchar(255) NOT NULL,
+  `LatencyTestId` int(11) NOT NULL,
+  `MaxFlightConsumerLag` int(11) NOT NULL,
+  `MaxWeatherConsumerLag` int(11) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Struktur-dump for tabellen `ExperimentResult`
+--
+
+CREATE TABLE `ExperimentResult` (
+  `Id` int(11) NOT NULL,
+  `ExperimentId` varchar(36) NOT NULL,
+  `ExperimentRunDescription` varchar(255) NOT NULL,
+  `UTCStartTime` datetime DEFAULT NULL,
+  `UTCEndTime` datetime DEFAULT NULL,
+  `ExperimentError` varchar(255) DEFAULT NULL,
+  `ExperimentSuccess` tinyint(1) NOT NULL DEFAULT 0
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Struktur-dump for tabellen `LatencyTest`
+--
+
+CREATE TABLE `LatencyTest` (
+  `Id` int(11) NOT NULL,
+  `SamplePoints` int(11) NOT NULL,
+  `SampleDelayMs` int(11) NOT NULL,
+  `AverageLatencyMs` double NOT NULL,
+  `MedianLatencyMs` double NOT NULL,
+  `StdDeviationLatency` double NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+--
+-- Begrænsninger for dumpede tabeller
+--
+
+--
+-- Indeks for tabel `EventLog_Flight`
+--
+ALTER TABLE `EventLog_Flight`
+  ADD PRIMARY KEY (`Id`),
+  ADD KEY `experiment_results_flightevent` (`ExperimentId`),
+  ADD KEY `experiment_clientid_flight` (`ClientId`);
+
+--
+-- Indeks for tabel `EventLog_Recalculation`
+--
+ALTER TABLE `EventLog_Recalculation`
+  ADD PRIMARY KEY (`Id`),
+  ADD KEY `experiment_results_recalculationevent` (`ExperimentId`),
+  ADD KEY `experiment_clientid_recalculation` (`ClientId`);
+
+--
+-- Indeks for tabel `EventLog_Weather`
+--
+ALTER TABLE `EventLog_Weather`
+  ADD PRIMARY KEY (`Id`),
+  ADD KEY `experiment_results_weatherevent` (`ExperimentId`),
+  ADD KEY `experiment_clientid_weather` (`ClientId`);
+
+--
+-- Indeks for tabel `Experiment`
+--
+ALTER TABLE `Experiment`
+  ADD PRIMARY KEY (`Id`);
+
+--
+-- Indeks for tabel `ExperimentClientResult`
+--
+ALTER TABLE `ExperimentClientResult`
+  ADD PRIMARY KEY (`Id`),
+  ADD UNIQUE KEY `one_clientresult_per_result` (`ExperimentResultId`,`ClientId`),
+  ADD KEY `latency_test_link` (`LatencyTestId`),
+  ADD KEY `client_id_index` (`ClientId`);
+
+--
+-- Indeks for tabel `ExperimentResult`
+--
+ALTER TABLE `ExperimentResult`
+  ADD PRIMARY KEY (`Id`),
+  ADD KEY `experiment_results` (`ExperimentId`);
+
+--
+-- Indeks for tabel `LatencyTest`
+--
+ALTER TABLE `LatencyTest`
+  ADD PRIMARY KEY (`Id`);
+
+--
+-- Brug ikke AUTO_INCREMENT for slettede tabeller
+--
+
+--
+-- Tilføj AUTO_INCREMENT i tabel `EventLog_Flight`
+--
+ALTER TABLE `EventLog_Flight`
+  MODIFY `Id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- Tilføj AUTO_INCREMENT i tabel `EventLog_Recalculation`
+--
+ALTER TABLE `EventLog_Recalculation`
+  MODIFY `Id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- Tilføj AUTO_INCREMENT i tabel `EventLog_Weather`
+--
+ALTER TABLE `EventLog_Weather`
+  MODIFY `Id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- Tilføj AUTO_INCREMENT i tabel `ExperimentClientResult`
+--
+ALTER TABLE `ExperimentClientResult`
+  MODIFY `Id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- Tilføj AUTO_INCREMENT i tabel `ExperimentResult`
+--
+ALTER TABLE `ExperimentResult`
+  MODIFY `Id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- Tilføj AUTO_INCREMENT i tabel `LatencyTest`
+--
+ALTER TABLE `LatencyTest`
+  MODIFY `Id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- Begrænsninger for dumpede tabeller
+--
+
+--
+-- Begrænsninger for tabel `EventLog_Flight`
+--
+ALTER TABLE `EventLog_Flight`
+  ADD CONSTRAINT `experiment_clientid_flight` FOREIGN KEY (`ClientId`) REFERENCES `ExperimentClientResult` (`ClientId`) ON DELETE CASCADE,
+  ADD CONSTRAINT `experiment_results_flightevent` FOREIGN KEY (`ExperimentId`) REFERENCES `Experiment` (`Id`) ON DELETE CASCADE;
+
+--
+-- Begrænsninger for tabel `EventLog_Recalculation`
+--
+ALTER TABLE `EventLog_Recalculation`
+  ADD CONSTRAINT `experiment_clientid_recalculation` FOREIGN KEY (`ClientId`) REFERENCES `ExperimentClientResult` (`ClientId`),
+  ADD CONSTRAINT `experiment_results_recalculationevent` FOREIGN KEY (`ExperimentId`) REFERENCES `Experiment` (`Id`) ON DELETE CASCADE;
+
+--
+-- Begrænsninger for tabel `EventLog_Weather`
+--
+ALTER TABLE `EventLog_Weather`
+  ADD CONSTRAINT `experiment_clientid_weather` FOREIGN KEY (`ClientId`) REFERENCES `ExperimentClientResult` (`ClientId`) ON DELETE CASCADE,
+  ADD CONSTRAINT `experiment_results_weatherevent` FOREIGN KEY (`ExperimentId`) REFERENCES `Experiment` (`Id`) ON DELETE CASCADE;
+
+--
+-- Begrænsninger for tabel `ExperimentClientResult`
+--
+ALTER TABLE `ExperimentClientResult`
+  ADD CONSTRAINT `experiment_result_link` FOREIGN KEY (`ExperimentResultId`) REFERENCES `ExperimentResult` (`Id`) ON DELETE CASCADE,
+  ADD CONSTRAINT `latency_test_link` FOREIGN KEY (`LatencyTestId`) REFERENCES `LatencyTest` (`Id`) ON DELETE CASCADE;
+
+--
+-- Begrænsninger for tabel `ExperimentResult`
+--
+ALTER TABLE `ExperimentResult`
+  ADD CONSTRAINT `experiment_results` FOREIGN KEY (`ExperimentId`) REFERENCES `Experiment` (`Id`) ON DELETE CASCADE;
+COMMIT;
+
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;


### PR DESCRIPTION
Closes #34 

This changes the database-schema so that collected data is stored per `ExperimentClientResult` instead of per `Experiment`. This is done by referencing the `ClientId` on each point of collected data.

This also adjusts the ExperimentView page so it contains links to download the collected data. 