### PR TITLE
BugFix: Respect experiment and preload start-times

### DIFF
--- a/DynamicFlightStorageSimulation/FlightInjector.cs
+++ b/DynamicFlightStorageSimulation/FlightInjector.cs
@@ -48,6 +48,15 @@ public class FlightInjector
         return flightList.OrderBy(x => x.DatePlanned).ToList();
     }
 
+    public void SkipFlightsUntil(DateTime date, CancellationToken cancellationToken = default)
+    {
+        // This is ugly, but it works
+        foreach (var _ in GetFlightsUntill(date, cancellationToken))
+        {
+            // Don't do anything
+        }
+    }
+
     public async Task PublishFlightsUntil(DateTime date, string experimentId, ILogger? logger = null, CancellationToken cancellationToken = default)
     {
         var flightsToPublish = GetFlightsUntill(date, cancellationToken).ToList();

--- a/DynamicFlightStorageSimulation/WeatherInjector.cs
+++ b/DynamicFlightStorageSimulation/WeatherInjector.cs
@@ -37,6 +37,15 @@ public class WeatherInjector
         _tafFiles = new(FindFiles(_tafPath));
     }
 
+    public void SkipWeatherUntil(DateTime date, CancellationToken cancellationToken = default)
+    {
+        // This is ugly, but it works
+        foreach (var _ in GetWeatherUntil(date, cancellationToken))
+        {
+            // Don't do anything
+        }
+    }
+
     public async Task PublishWeatherUntil(DateTime date, string experimentId, ILogger? logger = null, CancellationToken cancellationToken = default)
     {
         var weatherBatches = GetWeatherUntil(date, cancellationToken).ToList();

--- a/DynamicFlightStorageUI/Components/Shared/ExperimentSelector.razor
+++ b/DynamicFlightStorageUI/Components/Shared/ExperimentSelector.razor
@@ -2,6 +2,8 @@
 @using Microsoft.EntityFrameworkCore;
 @inject DataCollectionContext dbContext
 @inject DataSetManager dataSetManager
+@inject IJSRuntime jsRuntime
+@inject ILogger<ExperimentSelector> logger
 <h3>Current Experiment:</h3>
 @if(Experiment is not null)
 {
@@ -179,7 +181,14 @@ else
     {
         if(Experiments.FirstOrDefault(x=> x.Id == SelectedExperimentId) is { } newExperiment)
         {
-            await OnExperimentChanged.InvokeAsync(newExperiment);
+            try{
+                await OnExperimentChanged.InvokeAsync(newExperiment);
+            }
+            catch(Exception ex)
+            {
+                logger.LogError(ex, "Failed to set new experiment");
+                await jsRuntime.InvokeVoidAsync("alert", "Failed to set new experiment\n" + ex.Message);
+            }
         }
     }
 


### PR DESCRIPTION
Closes #33

This PR ensures that the weather and flightinjectors skip ahead accordingly based on the start-times of the experiment.