### PR TITLE
Fixing METAR valid time range

### DIFF
--- a/DynamicFlightStorageSimulation/WeatherCreator.cs
+++ b/DynamicFlightStorageSimulation/WeatherCreator.cs
@@ -74,7 +74,7 @@ public static class WeatherCreator
             {
                 Id = identifier,
                 ValidFrom = dateIssued,
-                ValidTo = dateIssued,
+                ValidTo = dateIssued.AddHours(1),
                 Airport = airportId,
                 WeatherLevel = category,
                 DateIssued = dateIssued


### PR DESCRIPTION
Adding one hour to METAR weather's validTo date, such that each METAR is valid for an hour