### PR TITLE
Neo4j Graph Implementations

### DIFF
--- a/DynamicFlightStorage.sln
+++ b/DynamicFlightStorage.sln
@@ -27,6 +27,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SimplePostgreSQLDataStore",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OptimizedPostgreSQLDataStore", "EventDataStores\OptimizedPostgreSQLDataStore\OptimizedPostgreSQLDataStore.csproj", "{511915AD-0643-41F9-8E17-F66EF1AD3F23}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Neo4jDataStore", "EventDataStores\Neo4jDataStore\Neo4jDataStore.csproj", "{E7B64365-3D92-4962-A1C3-1BC57D3430C9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -73,6 +75,10 @@ Global
 		{511915AD-0643-41F9-8E17-F66EF1AD3F23}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{511915AD-0643-41F9-8E17-F66EF1AD3F23}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{511915AD-0643-41F9-8E17-F66EF1AD3F23}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E7B64365-3D92-4962-A1C3-1BC57D3430C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E7B64365-3D92-4962-A1C3-1BC57D3430C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E7B64365-3D92-4962-A1C3-1BC57D3430C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E7B64365-3D92-4962-A1C3-1BC57D3430C9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -83,6 +89,7 @@ Global
 		{4D18D77F-5706-4738-A4BC-EF7F0F8AAF28} = {FAAA45D3-B333-4765-8E9C-154273EA7A2B}
 		{00240B2D-2701-4ED0-B92C-240121B6F7DF} = {F618F1D0-7CB1-442B-8CCA-C90FF84D66AE}
 		{511915AD-0643-41F9-8E17-F66EF1AD3F23} = {F618F1D0-7CB1-442B-8CCA-C90FF84D66AE}
+		{E7B64365-3D92-4962-A1C3-1BC57D3430C9} = {F618F1D0-7CB1-442B-8CCA-C90FF84D66AE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B1900E86-D897-43A4-8BD5-B4074AF1F004}

--- a/DynamicFlightStorageDTOs/IWeatherService.cs
+++ b/DynamicFlightStorageDTOs/IWeatherService.cs
@@ -3,5 +3,6 @@
     public interface IWeatherService
     {
         Weather GetWeather(string airport, DateTime dateTime);
+        void ResetWeatherService();
     }
 }

--- a/DynamicFlightStorageSimulation/SimulationConsumer.cs
+++ b/DynamicFlightStorageSimulation/SimulationConsumer.cs
@@ -65,7 +65,7 @@ namespace DynamicFlightStorageSimulation
         private async Task ResetStateAsync(SystemMessage message)
         {
             var experimentId = message.Message;
-            _weatherService.Clear();
+            _weatherService.ResetWeatherService();
             _consumerLogger.ResetLogger();
             if (!cleanState)
             {

--- a/DynamicFlightStorageSimulation/SimulationConsumer.cs
+++ b/DynamicFlightStorageSimulation/SimulationConsumer.cs
@@ -43,7 +43,10 @@ namespace DynamicFlightStorageSimulation
         private async Task OnWeatherRecieved(WeatherEvent weatherEvent)
         {
             _consumerLogger.LogWeatherData(weatherEvent);
-            cleanState = false;
+            if (cleanState)
+            {
+                cleanState = false;
+            }
             var weather = weatherEvent.Weather;
             _weatherService.AddWeather(weather);
             await _eventDataStore.AddWeatherAsync(weather).ConfigureAwait(false);
@@ -52,7 +55,10 @@ namespace DynamicFlightStorageSimulation
         private async Task OnFlightRecieved(FlightEvent flight)
         {
             _consumerLogger.LogFlightData(flight);
-            cleanState = false;
+            if (cleanState)
+            {
+                cleanState = false;
+            }
             await _eventDataStore.AddOrUpdateFlightAsync(flight.Flight).ConfigureAwait(false);
         }
 

--- a/DynamicFlightStorageSimulation/SimulationEventBus.cs
+++ b/DynamicFlightStorageSimulation/SimulationEventBus.cs
@@ -112,6 +112,24 @@ namespace DynamicFlightStorageSimulation
             await _rabbitChannel.ExchangeDeclareAsync(GetWeatherExperimentExchange(experimentId), ExchangeType.Fanout, autoDelete: true);
         }
 
+        public async Task DeleteExperimentExchanges(string experimentId)
+        {
+            if (_rabbitChannel is null)
+            {
+                throw new InvalidOperationException("Not connected to the event bus");
+            }
+
+            try
+            {
+                await _rabbitChannel.ExchangeDeleteAsync(GetFlightExperimentExchange(experimentId));
+                await _rabbitChannel.ExchangeDeleteAsync(GetWeatherExperimentExchange(experimentId));
+            }
+            catch
+            {
+                 // We don't actually care, exhcanged are auto-delete anyway, so they'll die eventually
+            }
+        }
+
         public string GetFlightExperimentExchange(string experimentId) => $"{_eventBusConfig.FlightTopic}.{experimentId}";
         public string GetWeatherExperimentExchange(string experimentId) => $"{_eventBusConfig.WeatherTopic}.{experimentId}";
 

--- a/DynamicFlightStorageSimulation/SimulationEventBus.cs
+++ b/DynamicFlightStorageSimulation/SimulationEventBus.cs
@@ -68,6 +68,21 @@ namespace DynamicFlightStorageSimulation
             _logger?.LogInformation("Bound to new experiment {ExperimentId}", experimentId);
         }
 
+        public async Task UnSubscribeFromExperiment()
+        {
+            if (string.IsNullOrWhiteSpace(CurrentExperimentId) || _rabbitChannel is null)
+            {
+                return;
+            }
+
+            await TryUnbindQueueFromExchange(FlightQueueName, GetFlightExperimentExchange(CurrentExperimentId));
+            await TryUnbindQueueFromExchange(WeatherQueueName, GetWeatherExperimentExchange(CurrentExperimentId));
+            await _rabbitChannel.QueuePurgeAsync(FlightQueueName);
+            await _rabbitChannel.QueuePurgeAsync(WeatherQueueName);
+            _logger?.LogInformation("Unbound from experiment {ExperimentId}", CurrentExperimentId);
+            CurrentExperimentId = string.Empty;
+        }
+
         private async Task TryUnbindQueueFromExchange(string queue, string exchange)
         {
             if (_rabbitChannel is null)

--- a/DynamicFlightStorageSimulation/WeatherCreator.cs
+++ b/DynamicFlightStorageSimulation/WeatherCreator.cs
@@ -228,7 +228,6 @@ public static class WeatherCreator
         {
             throw new ArgumentException($"Invalid date for {identifier}");
         }
-
-        return DateTime.Parse(dateString);
+        return DateTime.Parse(dateString).ToUniversalTime();
     }
 }

--- a/DynamicFlightStorageSimulation/WeatherService.cs
+++ b/DynamicFlightStorageSimulation/WeatherService.cs
@@ -19,11 +19,12 @@ namespace DynamicFlightStorageSimulation
 
             if (_weather.TryGetValue(airport, out var weatherInstances))
             {
-                var weather = weatherInstances.Find(weather => weather.ValidFrom <= dateTime && weather.ValidTo >= dateTime);
+                var weather = weatherInstances
+                    .Where(weather => weather.ValidFrom <= dateTime && weather.ValidTo >= dateTime);
 
-                if (weather is not null)
+                if (weather.Any())
                 {
-                    return weather;
+                    return weather.MaxBy(x => x.DateIssued)!;
                 }
 
                 var smallestDiff = TimeSpan.MaxValue;
@@ -66,7 +67,7 @@ namespace DynamicFlightStorageSimulation
             });
         }
 
-        public void Clear()
+        public void ResetWeatherService()
         {
             _weather.Clear();
         }

--- a/DynamicFlightStorageUI/Components/Pages/Experiments.razor
+++ b/DynamicFlightStorageUI/Components/Pages/Experiments.razor
@@ -18,7 +18,7 @@
                 
                 <h5>Results</h5>
                 <ul>
-                    @foreach(var result in experiment.ExperimentResults.OrderBy(x=>x.UTCEndTime))
+                    @foreach(var result in experiment.ExperimentResults.OrderBy(x=>x.UTCStartTime))
                     {
                         <li>
                             @if (result.ExperimentSuccess)

--- a/DynamicFlightStorageUI/Components/Pages/Home.razor
+++ b/DynamicFlightStorageUI/Components/Pages/Home.razor
@@ -28,8 +28,8 @@
             <h3>Run an experiment: <button class="btn btn-sm" @onclick="StateHasChanged">Refresh state</button></h3>
             <p>An experiment is running: @(orchestrator.CheckExperimentRunning())</p>
             @if(orchestrator.CurrentSimulationTime is { } simTime
-             && orchestrator.CurrentExperiment is { } currEx
-             && orchestrator.CurrentExperimentResult is { } result)
+            && orchestrator.CurrentExperiment is { } currEx
+            && orchestrator.CurrentExperimentResult is { } result)
             {
                 bool experimentDone = result.UTCEndTime is not null;
                 string barColor = "";
@@ -322,10 +322,10 @@
                 OnOrchestratorLog(new LogEntry(LogLevel.Error, $"Failed to find data store {SelectedDataStore}", null));
                 return;
             }
-            
+
             var weatherService = new WeatherService();
             OnOrchestratorLog(new LogEntry(LogLevel.Information, $"Creating internal consumer of type {SelectedDataStore}", null));
-            
+
             IEventDataStore dataStore = dataStoreFactory(weatherService, eventbus);
 
             var newConsumer = new SimulationConsumer(eventbus,
@@ -339,6 +339,10 @@
 
             consumer = newConsumer;
             KnownClientIds.Add(consumer.ClientId);
+        }
+        catch(Exception e)
+        {
+            OnOrchestratorLog(new LogEntry(LogLevel.Error, $"Failed to start consumer of type {SelectedDataStore}", e));
         }
         finally
         {

--- a/DynamicFlightStorageUI/Components/Pages/Home.razor
+++ b/DynamicFlightStorageUI/Components/Pages/Home.razor
@@ -304,6 +304,8 @@
         { "Basic in-memory data-store", (w, e) => new BasicEventDataStore.BasicEventDataStore(w, e) },
         { "Simple PostgreSQL (EF-Core backed)", (w, e) => new SimplePostgreSQLDataStore.SimplePostgreSQLDataStore(w, e) },
         { "Optimized PostgreSQL (BTree indexes)", (w, e) => new OptimizedPostgreSQLDataStore.BTreePostgreSQLDataStore(w, e) },
+        { "Neo4J Relational", (w, e) => new Neo4jDataStore.RelationalNeo4jDataStore(w, e) },
+        { "Neo4J Time-Buckets", (w, e) => new Neo4jDataStore.TimeBucketedNeo4jDataStore(w, e) },
     };
 
     private async Task CreateConsumer()

--- a/DynamicFlightStorageUI/Components/Pages/ManualPublishing.razor
+++ b/DynamicFlightStorageUI/Components/Pages/ManualPublishing.razor
@@ -1,7 +1,9 @@
 ﻿@page "/manual"
+@using DynamicFlightStorageSimulation.ExperimentOrchestrator
 @using DynamicFlightStorageSimulation.Utilities
 @inject SimulationEventBus eventbus
 @inject IJSRuntime jsRuntime
+@inject Orchestrator orchestrator
 @implements IDisposable
 <h1>Prototyping Dashboard!</h1>
 <div class="container mb-2">
@@ -15,7 +17,7 @@
 
     @if (!ExperimentCreated)
     {
-        <p>Create a temporary experiment to publish data.</p>
+        <p>Create a temporary experiment to publish data OR start a real experiment before visiting this page.</p>
     }
     else
     {
@@ -31,7 +33,7 @@
         </div>
 
     }
-    <div class="row">
+    <div class="row mt-4">
         <div class="col">
             <h3>Logs:</h3>
             <ul id="logList" class="logContainer list-unstyled"></ul>
@@ -43,11 +45,19 @@
     private bool ExperimentCreated { get; set; } = false;
     private string CurrentExperimentId { get; set; } = Guid.NewGuid().ToString();
 
-    protected override void OnAfterRender(bool firstRender)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if(firstRender)
         {
             eventbus.SubscribeToSystemEvent(OnSystemMessage);
+            await eventbus.SubscribeToRecalculationEventAsync(OnRecalculation);
+
+            if (orchestrator.CurrentExperimentResult is { } result)
+            {
+                CurrentExperimentId = result.ExperimentId;
+                ExperimentCreated = true;
+                StateHasChanged();
+            }
         }
     }
 
@@ -66,6 +76,7 @@
 
     private async Task PublishWeather(Weather weather)
     {
+        weather.DateIssued = DateTime.UtcNow;
         await eventbus.PublishWeatherAsync(weather, CurrentExperimentId).ConfigureAwait(false);
     }
 
@@ -80,6 +91,12 @@
         return Task.CompletedTask;
     }
 
+    private Task OnRecalculation(FlightRecalculation message)
+    {
+        Log(new LogEntry(LogLevel.Information, $"[{message.ClientId}::Recalculation] {message.FlightIdentification} (Experiment: {message.ExperimentId})", null));
+        return Task.CompletedTask;
+    }
+
     private void Log(LogEntry log)
     {
         _ = jsRuntime.InvokeVoidAsync("logMessage", log);
@@ -87,6 +104,7 @@
 
     public void Dispose()
     {
+        eventbus.UnSubscribeToRecalculationEvent(OnRecalculation);
         eventbus.UnSubscribeToSystemEvent(OnSystemMessage);
         if (ExperimentCreated)
         {

--- a/DynamicFlightStorageUI/Components/Pages/ManualPublishing.razor
+++ b/DynamicFlightStorageUI/Components/Pages/ManualPublishing.razor
@@ -8,20 +8,29 @@
     <div class="row">
         <div class="mb-3">
             <label for="experimentIdInput" class="form-label">Current Experiment Id:</label>
-            <input type="text" class="form-control" id="experimentIdInput" @bind="CurrentExperimentId">
-            <button class="btn btn-success" @onclick=StartExperiment>Start Experiment</button>
+            <input type="text" class="form-control" disabled="@ExperimentCreated" id="experimentIdInput" @bind="CurrentExperimentId">
+            <button class="btn btn-success" disabled="@ExperimentCreated" @onclick=StartExperiment>Start Experiment</button>
         </div>
     </div>
-    <div class="row g-2 mb-2">
-        <div class="col-6 border rounded p-2">
-            <h3>Publish Weather:</h3>
-            <WeatherBuilder OnWeatherCreated="PublishWeather" />
+
+    @if (!ExperimentCreated)
+    {
+        <p>Create a temporary experiment to publish data.</p>
+    }
+    else
+    {
+        <div class="row g-2 mb-2">
+            <div class="col-6 border rounded p-2">
+                <h3>Publish Weather:</h3>
+                <WeatherBuilder OnWeatherCreated="PublishWeather" />
+            </div>
+            <div class="col-6 border rounded p-2">
+                <h3>Publish Flight:</h3>
+                <FlightBuilder OnFlightCreated="PublishFlight" />
+            </div>
         </div>
-        <div class="col-6 border rounded p-2">
-            <h3>Publish Flight:</h3>
-            <FlightBuilder OnFlightCreated="PublishFlight" />
-        </div>
-    </div>
+
+    }
     <div class="row">
         <div class="col">
             <h3>Logs:</h3>
@@ -31,6 +40,7 @@
 </div>
 
 @code {
+    private bool ExperimentCreated { get; set; } = false;
     private string CurrentExperimentId { get; set; } = Guid.NewGuid().ToString();
 
     protected override void OnAfterRender(bool firstRender)
@@ -51,6 +61,7 @@
                 Source = "ManualPublishing",
                 TimeStamp = DateTime.UtcNow
             });
+        ExperimentCreated = true;
     }
 
     private async Task PublishWeather(Weather weather)
@@ -77,5 +88,9 @@
     public void Dispose()
     {
         eventbus.UnSubscribeToSystemEvent(OnSystemMessage);
+        if (ExperimentCreated)
+        {
+            eventbus.DeleteExperimentExchanges(CurrentExperimentId).GetAwaiter().GetResult();
+        }
     }
 }

--- a/DynamicFlightStorageUI/Components/Pages/ManualPublishing.razor
+++ b/DynamicFlightStorageUI/Components/Pages/ManualPublishing.razor
@@ -1,11 +1,15 @@
 ﻿@page "/manual"
+@using DynamicFlightStorageSimulation.Utilities
 @inject SimulationEventBus eventbus
+@inject IJSRuntime jsRuntime
+@implements IDisposable
 <h1>Prototyping Dashboard!</h1>
 <div class="container mb-2">
     <div class="row">
         <div class="mb-3">
             <label for="experimentIdInput" class="form-label">Current Experiment Id:</label>
             <input type="text" class="form-control" id="experimentIdInput" @bind="CurrentExperimentId">
+            <button class="btn btn-success" @onclick=StartExperiment>Start Experiment</button>
         </div>
     </div>
     <div class="row g-2 mb-2">
@@ -18,10 +22,37 @@
             <FlightBuilder OnFlightCreated="PublishFlight" />
         </div>
     </div>
+    <div class="row">
+        <div class="col">
+            <h3>Logs:</h3>
+            <ul id="logList" class="logContainer list-unstyled"></ul>
+        </div>
+    </div>
 </div>
 
 @code {
     private string CurrentExperimentId { get; set; } = Guid.NewGuid().ToString();
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if(firstRender)
+        {
+            eventbus.SubscribeToSystemEvent(OnSystemMessage);
+        }
+    }
+
+    private async Task StartExperiment()
+    {
+        await eventbus.CreateNewExperiment(CurrentExperimentId);
+        await eventbus.PublishSystemMessage(new SystemMessage()
+            {
+                MessageType = SystemMessage.SystemMessageType.NewExperiment,
+                Message = CurrentExperimentId,
+                Source = "ManualPublishing",
+                TimeStamp = DateTime.UtcNow
+            });
+    }
+
     private async Task PublishWeather(Weather weather)
     {
         await eventbus.PublishWeatherAsync(weather, CurrentExperimentId).ConfigureAwait(false);
@@ -30,5 +61,21 @@
     private async Task PublishFlight(Flight flight)
     {
         await eventbus.PublishFlightAsync(flight, CurrentExperimentId).ConfigureAwait(false);
+    }
+
+    private Task OnSystemMessage(SystemMessage message)
+    {
+        Log(new LogEntry(LogLevel.Information, $"[{message.Source}::{message.MessageType}] {message.Message}", null));
+        return Task.CompletedTask;
+    }
+
+    private void Log(LogEntry log)
+    {
+        _ = jsRuntime.InvokeVoidAsync("logMessage", log);
+    }
+
+    public void Dispose()
+    {
+        eventbus.UnSubscribeToSystemEvent(OnSystemMessage);
     }
 }

--- a/DynamicFlightStorageUI/DynamicFlightStorageUI.csproj
+++ b/DynamicFlightStorageUI/DynamicFlightStorageUI.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\DynamicFlightStorageSimulation\DynamicFlightStorageSimulation.csproj" />
     <ProjectReference Include="..\EventDataStores\BasicEventDataStore\BasicEventDataStore.csproj" />
+    <ProjectReference Include="..\EventDataStores\Neo4jDataStore\Neo4jDataStore.csproj" />
     <ProjectReference Include="..\EventDataStores\OptimizedPostgreSQLDataStore\OptimizedPostgreSQLDataStore.csproj" />
     <ProjectReference Include="..\EventDataStores\SimplePostgreSQLDataStore\SimplePostgreSQLDataStore.csproj" />
   </ItemGroup>

--- a/EventDataStores/Neo4jDataStore/CommonGraphDatabaseCommands.cs
+++ b/EventDataStores/Neo4jDataStore/CommonGraphDatabaseCommands.cs
@@ -1,0 +1,28 @@
+﻿using Neo4j.Driver;
+
+namespace Neo4jDataStore
+{
+    internal static class CommonGraphDatabaseCommands
+    {
+        internal static async Task CreateOrUpdateFlight(IAsyncQueryRunner tx, string flightId)
+        {
+            const string Query =
+                """
+                MERGE (f:Flight {id:$flightId})
+                SET f.recalculating = false;
+                """;
+            await tx.RunAsync(Query, new { flightId }).ConfigureAwait(false);
+        }
+
+        internal static async Task SetRecalculation(IAsyncQueryRunner tx, string[] flightIds)
+        {
+            const string Query =
+                """
+                MATCH (f:Flight)
+                WHERE f.id IN $flightIds
+                SET f.recalculating = true
+                """;
+            await tx.RunAsync(Query, new { flightIds }).ConfigureAwait(false);
+        }
+    }
+}

--- a/EventDataStores/Neo4jDataStore/DatabaseInit/relationalInit.cypher
+++ b/EventDataStores/Neo4jDataStore/DatabaseInit/relationalInit.cypher
@@ -1,0 +1,7 @@
+// A STATEMENT ONLY ON ONE LINE, AND ONLY ONE PER LINE.
+// Adding contstraints automatically adds indexes on the same properties
+CREATE CONSTRAINT airport_icao_unique FOR (a:Airport) REQUIRE a.icao IS UNIQUE
+CREATE CONSTRAINT flight_id_unique FOR (f:Flight) REQUIRE f.id IS UNIQUE
+CREATE INDEX airport_dep FOR () -[r:USES]-> () ON (r.dep);
+CREATE INDEX airport_arr FOR () -[r:USES]-> () ON (r.arr);
+CREATE INDEX airport_weather FOR () -[r:USES]-> () ON (r.weather); 

--- a/EventDataStores/Neo4jDataStore/DatabaseInit/timeBucketedInit.cypher
+++ b/EventDataStores/Neo4jDataStore/DatabaseInit/timeBucketedInit.cypher
@@ -1,0 +1,9 @@
+// A STATEMENT ONLY ON ONE LINE, AND ONLY ONE PER LINE.
+// Adding contstraints automatically adds indexes on the same properties
+CREATE CONSTRAINT airport_icao_unique FOR (a:Airport) REQUIRE a.icao IS UNIQUE
+CREATE CONSTRAINT flight_id_unique FOR (f:Flight) REQUIRE f.id IS UNIQUE
+CREATE CONSTRAINT timebucket_unique FOR (t:TimeBucket) REQUIRE (t.icao, t.timeSliceStart) IS UNIQUE
+CREATE INDEX timebucket_start FOR (t:TimeBucket) ON (t.timeSliceStart);
+CREATE INDEX uses_dep FOR () -[r:USES]-> () ON (r.dep);
+CREATE INDEX uses_arr FOR () -[r:USES]-> () ON (r.arr);
+CREATE INDEX uses_weather FOR () -[r:USES]-> () ON (r.weather); 

--- a/EventDataStores/Neo4jDataStore/Neo4jDataStore.csproj
+++ b/EventDataStores/Neo4jDataStore/Neo4jDataStore.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Neo4j.Driver" Version="5.27.0" />
+    <PackageReference Include="Testcontainers.Neo4j" Version="4.1.0" />
+    <PackageReference Include="Testcontainers" Version="4.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\DynamicFlightStorageDTOs\DynamicFlightStorageDTOs.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="DatabaseInit\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="DatabaseInit\relationalInit.cypher">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/EventDataStores/Neo4jDataStore/Neo4jDataStore.csproj
+++ b/EventDataStores/Neo4jDataStore/Neo4jDataStore.csproj
@@ -17,11 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="DatabaseInit\" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="DatabaseInit\relationalInit.cypher">
+    <None Update="DatabaseInit\*.cypher">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/EventDataStores/Neo4jDataStore/RelationalNeo4jDataStore.cs
+++ b/EventDataStores/Neo4jDataStore/RelationalNeo4jDataStore.cs
@@ -1,0 +1,246 @@
+﻿using DynamicFlightStorageDTOs;
+using Neo4j.Driver;
+using Testcontainers.Neo4j;
+
+namespace Neo4jDataStore
+{
+    public class RelationalNeo4jDataStore : IEventDataStore, IDisposable
+    {
+        private Neo4jContainer? _container;
+        private IDriver? _database;
+        private static readonly QueryConfig QueryConfig = new QueryConfig(database: "neo4j");
+        private readonly IWeatherService _weatherService;
+        private readonly IRecalculateFlightEventPublisher _flightRecalculation;
+        public RelationalNeo4jDataStore(IWeatherService weatherService, IRecalculateFlightEventPublisher recalculateFlightEventPublisher)
+        {
+            _weatherService = weatherService ?? throw new ArgumentNullException(nameof(weatherService));
+            _flightRecalculation = recalculateFlightEventPublisher ?? throw new ArgumentNullException(nameof(recalculateFlightEventPublisher));
+        }
+
+        public async Task StartAsync()
+        {
+            _container = new Neo4jBuilder()
+#if DEBUG
+                .WithExposedPort(7474)
+#endif
+                .Build();
+            await _container.StartAsync();
+
+            var driver = GraphDatabase.Driver(_container.GetConnectionString());
+            await driver.VerifyConnectivityAsync();
+
+            var initPath = Path.Combine(AppContext.BaseDirectory, "DatabaseInit", "relationalInit.cypher");
+            foreach (var line in await File.ReadAllLinesAsync(initPath).ConfigureAwait(false))
+            {
+                if (line.Trim().StartsWith("//"))
+                {
+                    continue;
+                }
+
+                await driver.ExecutableQuery(line)
+                    .WithConfig(QueryConfig)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+            }
+
+            _database = driver;
+
+#if DEBUG
+            Console.WriteLine($"Neo4j Relational ConnectionString: {_container.GetConnectionString()}.\n" +
+                $"Web-interface: http://localhost:{_container.GetMappedPublicPort(7474)}/browser?dbms={_container.GetConnectionString()}");
+#endif
+        }
+
+        public async Task ResetAsync()
+        {
+            if (_database is not null)
+            {
+                await _database.DisposeAsync().AsTask();
+            }
+            if (_container is not null)
+            {
+                await _container.DisposeAsync().AsTask();
+            }
+            await StartAsync();
+        }
+
+        public async Task AddOrUpdateFlightAsync(Flight flight)
+        {
+            if (_database is null)
+            {
+                throw new InvalidOperationException("Database is not ready");
+            }
+
+            await using var session = _database.AsyncSession();
+            // Executes it as a single transaction
+            await session.ExecuteWriteAsync(async tx =>
+            {
+                await CreateOrUpdateFlight(tx, flight.FlightIdentification);
+
+                var weather = _weatherService.GetWeatherCategoriesForFlight(flight);
+
+                foreach (var airport in flight.GetAllAirports().Distinct())
+                {
+                    // Insert the airport
+                    await CreateOrUpdateAirport(tx, airport);
+                    await CreateOrUpdateRelation(tx, flight.FlightIdentification, airport, weather.GetValueOrDefault(airport, WeatherCategory.Undefined),
+                        flight.ScheduledTimeOfDeparture, flight.ScheduledTimeOfArrival);
+                }
+            });
+        }
+
+        private async Task<IResultSummary> CreateOrUpdateFlight(IAsyncQueryRunner tx, string flightId)
+        {
+            const string Query =
+                """
+                MERGE (f:Flight {id:$flightId})
+                SET f.recalculating = false;
+                """;
+            return await (await tx.RunAsync(Query, new { flightId }).ConfigureAwait(false))
+                .ConsumeAsync().ConfigureAwait(false);
+        }
+
+        private async Task<IResultSummary> SetRecalculation(IAsyncQueryRunner tx, string[] flightIds)
+        {
+            //const string Query =
+            //    """
+            //    MATCH (f:Flight {id:$flightId});
+            //    SET f.recalculating = true 
+            //    """;
+            const string Query =
+                """
+                MATCH (f:Flight)
+                WHERE f.id IN $flightIds
+                SET f.recalculating = true
+                """;
+            return await (await tx.RunAsync(Query, new { flightIds }).ConfigureAwait(false))
+                .ConsumeAsync().ConfigureAwait(false);
+        }
+
+        private async Task<IResultSummary> CreateOrUpdateAirport(IAsyncQueryRunner tx, string icao)
+        {
+            const string Query =
+                """
+                MERGE (a:Airport {icao: $icao});
+                """;
+            return await (await tx.RunAsync(Query, new { icao }).ConfigureAwait(false))
+                .ConsumeAsync().ConfigureAwait(false);
+        }
+
+        private async Task<IResultSummary> CreateOrUpdateRelation(IAsyncQueryRunner tx,
+            string flightId, string icao, WeatherCategory weatherCategory, DateTimeOffset departure, DateTimeOffset arrival)
+        {
+            const string Query =
+                """
+                MATCH (f:Flight {id: $flightId})
+                MATCH (a:Airport {icao: $icao})
+                MERGE (a) -[e:USES]-> (f)
+                SET e.weather = $weatherLevel, e.dep = $departure, e.arr = $arrival;
+                """;
+            return await (await tx.RunAsync(Query, new
+            {
+                flightId,
+                icao,
+                weatherLevel = (int)weatherCategory,
+                departure = departure.ToUnixTimeSeconds(),
+                arrival = arrival.ToUnixTimeSeconds()
+            }).ConfigureAwait(false))
+                .ConsumeAsync().ConfigureAwait(false);
+        }
+
+
+        public async Task AddWeatherAsync(Weather weather)
+        {
+            if (_database is null)
+            {
+                throw new InvalidOperationException("Database is not ready");
+            }
+
+            await using var session = _database.AsyncSession();
+
+            const string SearchQuery =
+                   """
+                    MATCH 
+                        (a:Airport {icao: $icao}) 
+                        -[u:USES WHERE 
+                            u.weather < $weatherLevel
+                            and u.dep <= $validTo
+                            and $validFrom <= u.arr 
+                        ]-> 
+                        (f:Flight {recalculating: false}) 
+                    return f.id;
+                    """;
+
+            var result = await session.RunAsync(SearchQuery, new
+            {
+                icao = weather.Airport,
+                weatherLevel = (int)weather.WeatherLevel,
+                validFrom = ((DateTimeOffset)weather.ValidFrom).ToUnixTimeSeconds(),
+                validTo = ((DateTimeOffset)weather.ValidTo).ToUnixTimeSeconds(),
+            }).ConfigureAwait(false);
+
+            // Loop through the records asynchronously
+            if ((await result.PeekAsync().ConfigureAwait(false)) is not null)
+            {
+                var records = await result.ToListAsync().ConfigureAwait(false);
+
+                // Executes it as a single transaction
+                await session.ExecuteWriteAsync(async tx =>
+                {
+                    var recalculatedFlights = new string[records.Count];
+                    int i = 0;
+                    foreach (var record in records)
+                    {
+                        // Each current read in buffer can be reached via Current
+                        var fetched = record[0] as string;
+                        if (string.IsNullOrEmpty(fetched))
+                        {
+                            // Should not happen, but to be safe anyway
+                            Console.WriteLine("Flight ID was null or empty or not parse-able as a string: " + record[0]);
+                            continue;
+                        }
+
+                        await _flightRecalculation.PublishRecalculationAsync(fetched).ConfigureAwait(false);
+                        recalculatedFlights[i++] = fetched;
+                    }
+
+                    if (records.Count > 0)
+                    {
+                        await SetRecalculation(tx, recalculatedFlights.ToArray());
+                    }
+                });
+            }
+        }
+
+        public async Task DeleteFlightAsync(string id)
+        {
+            if (_database is null)
+            {
+                throw new InvalidOperationException("Database is not ready");
+            }
+
+            const string Query =
+                """
+                MATCH(n:Flight { name: $flightId})
+                DETACH DELETE n
+                """;
+
+            await using var session = _database.AsyncSession();
+            await session.RunAsync(new Query(Query, new { flightId = id }));
+        }
+
+        public void Dispose()
+        {
+            if (_database is not null)
+            {
+                _database.DisposeAsync().AsTask().GetAwaiter().GetResult();
+                _database = null;
+            }
+            if (_container is not null)
+            {
+                _container.DisposeAsync().AsTask().GetAwaiter().GetResult();
+                _container = null;
+            }
+        }
+    }
+}

--- a/EventDataStores/Neo4jDataStore/TimeBucketedNeo4jDataStore.cs
+++ b/EventDataStores/Neo4jDataStore/TimeBucketedNeo4jDataStore.cs
@@ -6,8 +6,11 @@ namespace Neo4jDataStore
 {
     public class TimeBucketedNeo4jDataStore : IEventDataStore, IDisposable
     {
+        public static readonly TimeSpan TimeBucketSize = TimeSpan.FromHours(1);
+
         private Neo4jContainer? _container;
         private IDriver? _database;
+        private static readonly QueryConfig QueryConfig = new QueryConfig(database: "neo4j");
         private readonly IWeatherService _weatherService;
         private readonly IRecalculateFlightEventPublisher _flightRecalculation;
         public TimeBucketedNeo4jDataStore(IWeatherService weatherService, IRecalculateFlightEventPublisher recalculateFlightEventPublisher)
@@ -27,6 +30,21 @@ namespace Neo4jDataStore
 
             var driver = GraphDatabase.Driver(_container.GetConnectionString());
             await driver.VerifyConnectivityAsync();
+
+            var initPath = Path.Combine(AppContext.BaseDirectory, "DatabaseInit", "timeBucketedInit.cypher");
+            foreach (var line in await File.ReadAllLinesAsync(initPath).ConfigureAwait(false))
+            {
+                if (line.Trim().StartsWith("//"))
+                {
+                    continue;
+                }
+
+                await driver.ExecutableQuery(line)
+                    .WithConfig(QueryConfig)
+                    .ExecuteAsync()
+                    .ConfigureAwait(false);
+            }
+
             _database = driver;
 
 #if DEBUG
@@ -50,9 +68,59 @@ namespace Neo4jDataStore
 
         public async Task AddOrUpdateFlightAsync(Flight flight)
         {
+            if (_database is null)
+            {
+                throw new InvalidOperationException("Database is not ready");
+            }
 
-            throw new NotImplementedException();
+            await using var session = _database.AsyncSession();
+            // Executes it as a single transaction
+            await session.ExecuteWriteAsync(async tx =>
+            {
+                await CommonGraphDatabaseCommands.CreateOrUpdateFlight(tx, flight.FlightIdentification);
+
+                var weather = _weatherService.GetWeatherCategoriesForFlight(flight);
+
+                foreach (var airport in flight.GetAllAirports().Distinct())
+                {
+                    await CreateOrUpdateTimeBucketRelation(tx, flight.FlightIdentification, airport, weather.GetValueOrDefault(airport, WeatherCategory.Undefined),
+                        flight.ScheduledTimeOfDeparture, flight.ScheduledTimeOfArrival);
+                }
+            });
         }
+
+        private async Task CreateOrUpdateTimeBucketRelation(IAsyncQueryRunner tx,
+            string flightId, string icao, WeatherCategory weatherCategory, DateTime departure, DateTime arrival)
+        {
+            const string TimeBucketCreationQuery =
+                """
+                MERGE (a:Airport {icao: $icao})
+                    WITH a
+                MERGE (a) -[h:HasFlightIn]-> (t:TimeBucket {icao: $icao, timeSliceStart: $timeSliceStart})
+                    WITH t
+                MATCH (f:Flight {id: $flightId})
+                MERGE (t) -[e:USES]-> (f)
+                SET e.weather = $weatherLevel, e.dep = $departure, e.arr = $arrival;
+                """;
+
+            await tx.RunAsync(TimeBucketCreationQuery, new
+            {
+                icao,
+                timeSliceStart = ((DateTimeOffset)GetTimeSlot(departure)).ToUnixTimeSeconds(),
+                flightId,
+                weatherLevel = (int)weatherCategory,
+                departure = ((DateTimeOffset)departure).ToUnixTimeSeconds(),
+                arrival = ((DateTimeOffset)arrival).ToUnixTimeSeconds()
+            }).ConfigureAwait(false);
+        }
+
+        private static DateTime GetTimeSlot(DateTime dateTime)
+        {
+            var ticksLeftOver = dateTime.Ticks % TimeBucketSize.Ticks;
+            var roundedDown = dateTime.Subtract(TimeSpan.FromTicks(ticksLeftOver));
+            return roundedDown;
+        }
+
 
         public async Task AddWeatherAsync(Weather weather)
         {

--- a/EventDataStores/Neo4jDataStore/TimeBucketedNeo4jDataStore.cs
+++ b/EventDataStores/Neo4jDataStore/TimeBucketedNeo4jDataStore.cs
@@ -1,0 +1,82 @@
+﻿using DynamicFlightStorageDTOs;
+using Neo4j.Driver;
+using Testcontainers.Neo4j;
+
+namespace Neo4jDataStore
+{
+    public class TimeBucketedNeo4jDataStore : IEventDataStore, IDisposable
+    {
+        private Neo4jContainer? _container;
+        private IDriver? _database;
+        private readonly IWeatherService _weatherService;
+        private readonly IRecalculateFlightEventPublisher _flightRecalculation;
+        public TimeBucketedNeo4jDataStore(IWeatherService weatherService, IRecalculateFlightEventPublisher recalculateFlightEventPublisher)
+        {
+            _weatherService = weatherService ?? throw new ArgumentNullException(nameof(weatherService));
+            _flightRecalculation = recalculateFlightEventPublisher ?? throw new ArgumentNullException(nameof(recalculateFlightEventPublisher));
+        }
+
+        public async Task StartAsync()
+        {
+            _container = new Neo4jBuilder()
+#if DEBUG
+                .WithExposedPort(7474)
+#endif
+                .Build();
+            await _container.StartAsync();
+
+            var driver = GraphDatabase.Driver(_container.GetConnectionString());
+            await driver.VerifyConnectivityAsync();
+            _database = driver;
+
+#if DEBUG
+            Console.WriteLine($"Neo4j Time-Bucketed ConnectionString: {_container.GetConnectionString()}.\n" +
+                $"Web-interface: http://localhost:{_container.GetMappedPublicPort(7474)}/browser?dbms={_container.GetConnectionString()}");
+#endif
+        }
+
+        public async Task ResetAsync()
+        {
+            if (_database is not null)
+            {
+                await _database.DisposeAsync().AsTask();
+            }
+            if (_container is not null)
+            {
+                await _container.DisposeAsync().AsTask();
+            }
+            await StartAsync();
+        }
+
+        public async Task AddOrUpdateFlightAsync(Flight flight)
+        {
+
+            throw new NotImplementedException();
+        }
+
+        public async Task AddWeatherAsync(Weather weather)
+        {
+
+            throw new NotImplementedException();
+        }
+
+        public async Task DeleteFlightAsync(string id)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Dispose()
+        {
+            if (_database is not null)
+            {
+                _database.DisposeAsync().AsTask().GetAwaiter().GetResult();
+                _database = null;
+            }
+            if (_container is not null)
+            {
+                _container.DisposeAsync().AsTask().GetAwaiter().GetResult();
+                _container = null;
+            }
+        }
+    }
+}

--- a/EventDataStores/Neo4jDataStore/TimeBucketedNeo4jDataStore.cs
+++ b/EventDataStores/Neo4jDataStore/TimeBucketedNeo4jDataStore.cs
@@ -7,7 +7,7 @@ namespace Neo4jDataStore
 {
     public class TimeBucketedNeo4jDataStore : IEventDataStore, IDisposable
     {
-        public static readonly TimeSpan TimeBucketSize = TimeSpan.FromHours(1);
+        public static readonly TimeSpan TimeBucketSize = TimeSpan.FromDays(1);
 
         private Neo4jContainer? _container;
         private IDriver? _database;

--- a/EventDataStores/SimplePostgreSQLDataStore/SimplePostgreSQLDataStore.cs
+++ b/EventDataStores/SimplePostgreSQLDataStore/SimplePostgreSQLDataStore.cs
@@ -108,7 +108,10 @@ namespace SimplePostgreSQLDataStore
 
                 await _flightRecalculation.PublishRecalculationAsync(flight.FlightIdentification).ConfigureAwait(false);
             }
-            await _dbContext.SaveChangesAsync();
+            if (affectedFlights.Count > 0)
+            {
+                await _dbContext.SaveChangesAsync();
+            }
         }
 
         public async Task DeleteFlightAsync(string id)

--- a/ExperimentRunner/ExperimentRunner.csproj
+++ b/ExperimentRunner/ExperimentRunner.csproj
@@ -21,6 +21,9 @@
   <ItemGroup>
     <ProjectReference Include="..\DynamicFlightStorageSimulation\DynamicFlightStorageSimulation.csproj" />
     <ProjectReference Include="..\EventDataStores\BasicEventDataStore\BasicEventDataStore.csproj" />
+    <ProjectReference Include="..\EventDataStores\Neo4jDataStore\Neo4jDataStore.csproj" />
+    <ProjectReference Include="..\EventDataStores\OptimizedPostgreSQLDataStore\OptimizedPostgreSQLDataStore.csproj" />
+    <ProjectReference Include="..\EventDataStores\SimplePostgreSQLDataStore\SimplePostgreSQLDataStore.csproj" />
   </ItemGroup>
 
 

--- a/ExperimentRunner/Program.cs
+++ b/ExperimentRunner/Program.cs
@@ -42,7 +42,7 @@ namespace ExperimentRunner
             var weatherService = new WeatherService();
 
             // The event store to experiment with. Change me!
-            var eventDataStore = new BasicEventDataStore.BasicEventDataStore(weatherService, simulationEventBus);
+            var eventDataStore = new Neo4jDataStore.TimeBucketedNeo4jDataStore(weatherService, simulationEventBus);
 
             logger.LogInformation("Event data store of type {Type} ready", eventDataStore.GetType().FullName);
             using var consumer = new SimulationConsumer(simulationEventBus, weatherService, consumerDataLogger, eventDataStore, factory.CreateLogger<SimulationConsumer>());

--- a/ExperimentRunner/Program.cs
+++ b/ExperimentRunner/Program.cs
@@ -4,8 +4,6 @@ using DynamicFlightStorageSimulation.ExperimentOrchestrator.DataCollection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Console;
-using Microsoft.Extensions.Options;
 using System.ComponentModel.DataAnnotations;
 
 namespace ExperimentRunner


### PR DESCRIPTION
Closes #45 

Adds two new implementations backed by a graph-database Neo4j. One is a "relational setup" which closely mimics the way we query PostgresSQL and the other is where we utilize the graph nature and creates Time-Buckets. The size of these TimeBuckets can easily be adjusted. Currently it is set to 1 day.

![Time Buckets Bigger](https://github.com/user-attachments/assets/89c8e5ac-4356-4b4b-9307-e7108847184d)

Time-Buckets also make sure to include a flight in multiple time-buckets if the flight overlaps more of them. A simplified example is shown here

![Time Buckets Simple](https://github.com/user-attachments/assets/a64d924e-f09b-493f-b4cb-172dba0079e9)

