### PR TITLE
Only log event and flight data after preload is done

### DIFF
--- a/DynamicFlightStorageDTOs/SystemMessage.cs
+++ b/DynamicFlightStorageDTOs/SystemMessage.cs
@@ -32,6 +32,7 @@ namespace DynamicFlightStorageDTOs
             AbortExperiment = 6,
             AbortSuccess = 7,
             ConsumerExperimentAbort = 8,
+            ExperimentPreloadDone = 9,
         }
 
         public override string ToString()

--- a/DynamicFlightStorageSimulation/DataCollection/ConsumerDataLogger.cs
+++ b/DynamicFlightStorageSimulation/DataCollection/ConsumerDataLogger.cs
@@ -20,12 +20,14 @@ namespace DynamicFlightStorageSimulation.DataCollection
         }
 
         public bool IsLoggingEnabled { get; set; } = false;
+        public bool IsPreloadDone { get; set; } = false;
+        public bool ShouldLog => IsLoggingEnabled && IsPreloadDone;
 
         private LinkedList<FlightLog> _flightLog = new();
         private LinkedList<WeatherLog> _weatherLog = new();
         public void LogFlightData(FlightEvent flight)
         {
-            if (IsLoggingEnabled)
+            if (ShouldLog)
             {
                 _flightLog.AddLast(new FlightLog(DateTime.UtcNow, flight.TimeStamp, flight.Flight));
             }
@@ -33,7 +35,7 @@ namespace DynamicFlightStorageSimulation.DataCollection
 
         public void LogWeatherData(WeatherEvent weather)
         {
-            if (IsLoggingEnabled)
+            if (ShouldLog)
             {
                 _weatherLog.AddLast(new WeatherLog(DateTime.UtcNow, weather.TimeStamp, weather.Weather));
             }
@@ -104,6 +106,7 @@ namespace DynamicFlightStorageSimulation.DataCollection
 
         public void ResetLogger()
         {
+            IsPreloadDone = false;
             _flightLog.Clear();
             _weatherLog.Clear();
         }

--- a/DynamicFlightStorageSimulation/SimulationConsumer.cs
+++ b/DynamicFlightStorageSimulation/SimulationConsumer.cs
@@ -156,6 +156,16 @@ namespace DynamicFlightStorageSimulation
                     _isCancelled = false;
                     await ResetStateAsync(message).ConfigureAwait(false);
                     break;
+                case SystemMessage.SystemMessageType.ExperimentPreloadDone:
+                    _consumerLogger.IsPreloadDone = true;
+                    await _simulationEventBus.PublishSystemMessage(new SystemMessage()
+                    {
+                        MessageType = SystemMessage.SystemMessageType.NewExperimentReady,
+                        Message = message.Message,
+                        Source = _simulationEventBus.ClientId,
+                        Targets = [message.Source],
+                    }).ConfigureAwait(false);
+                    break;
                 case SystemMessage.SystemMessageType.ExperimentComplete:
                     await _consumerLogger.PersistDataAsync(_simulationEventBus.CurrentExperimentId, ClientId).ConfigureAwait(false);
                     _consumerLogger.ResetLogger();


### PR DESCRIPTION
This PR adjusts the system such that we only log flight and weather data after preload is done.

This should save us some bandwidth and data-storage. 