### PR TITLE
Fix Cuda Datastore: Overlaps count when a flight ends excatly on weather start

### DIFF
--- a/EventDataStores/CudaFlightSystem/collisionSystemTest.cpp
+++ b/EventDataStores/CudaFlightSystem/collisionSystemTest.cpp
@@ -105,6 +105,10 @@ void testCollisionSystem() {
 	position = { -11, 0, 0 };
 	testCase("From outside, stops inside", &flight, &position, true, &flightsystem);
 
+	position = { -15, 0, 0 };
+	flight.flightDuration = 5;
+	testCase("From outside, stops excatly on start", &flight, &position, true, &flightsystem);
+
 	// Test cases with multiple airport-z-values
 	flight.position.x = 0;
 

--- a/EventDataStores/CudaFlightSystem/flight_system.cu
+++ b/EventDataStores/CudaFlightSystem/flight_system.cu
@@ -75,7 +75,7 @@ __global__ void checkCollisionsKernel(Flight* flights, int numFlights,
 		int xDest = dep.x + duration;
 		bool collision =
 			((dep.x >= box.min.x) && (dep.x <= box.max.x)) // Checks if flight starts inside the box
-			|| (dep.x < box.min.x && xDest > box.min.x); // Checks if flight intersects the box
+			|| (dep.x < box.min.x && xDest >= box.min.x); // Checks if flight intersects the box
 
 		if (collision) {
 			if (setRecalculating) {


### PR DESCRIPTION
Closes #87 
The CUDA datastore was not producing nearly enough recalculations when compared to our other implementations. Turns out, this was caused by the CUDA datastore not counting when a flight ended at the exact time a new weather event started.

